### PR TITLE
Implement no className prop rule on common components

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,14 @@
 
 module.exports = {
     rules: {
-        'moment-utc': require('./lib/rules/moment-utc')
+        'moment-utc': require('./lib/rules/moment-utc'),
+        'no-classname-on-common-components': require('./lib/rules/no-classname-on-common-components')
     },
     configs: {
         recommended: {
             rules: {
-                '7g/moment-utc': 1
+                '7g/moment-utc': 1,
+                '7g/no-classname-on-common-components': 1
             }
         }
     }

--- a/lib/rules/moment-utc.js
+++ b/lib/rules/moment-utc.js
@@ -1,10 +1,8 @@
-"use strict";
-
 module.exports = function(context) {
     return {
         "CallExpression": function(node) {
             if(node.callee.name === "moment")  {
-                var ancestors = context.getAncestors(node),
+                const ancestors = context.getAncestors(node),
                     parent = ancestors.pop();
                 if (!parent.property || parent.property.name !== 'utc') {
                     context.report(node, "Use moment.utc()");

--- a/lib/rules/no-classname-on-common-components.js
+++ b/lib/rules/no-classname-on-common-components.js
@@ -1,21 +1,12 @@
 "use strict";
 var getProp = require('jsx-ast-utils/getProp');
 
-var commonlyUsedComponents = [
-    'Button',
-    'ProfileImage',
-    'Icon',
-    'DotLoader',
-    'ObjectiveName',
-    'UserContentBlock',
-    'RichTextInput',
-];
-
 module.exports = function(context) {
+    var options = context.options[0] || {components: []};
     return {
         JSXElement: function(node) {
             var name = node.openingElement.name.name
-            if (commonlyUsedComponents.indexOf(name) === -1) {
+            if (options.components.indexOf(name) === -1) {
                 return;
             }
             var typeProp = getProp(node.openingElement.attributes, 'className');

--- a/lib/rules/no-classname-on-common-components.js
+++ b/lib/rules/no-classname-on-common-components.js
@@ -1,0 +1,30 @@
+"use strict";
+var getProp = require('jsx-ast-utils/getProp');
+
+var commonlyUsedComponents = [
+    'Button',
+    'ProfileImage',
+    'Icon',
+    'DotLoader',
+    'ObjectiveName',
+    'UserContentBlock',
+    'RichTextInput',
+];
+
+module.exports = function(context) {
+    return {
+        JSXElement: function(node) {
+            var name = node.openingElement.name.name
+            if (commonlyUsedComponents.indexOf(name) === -1) {
+                return;
+            }
+            var typeProp = getProp(node.openingElement.attributes, 'className');
+            if (!typeProp) {
+                return;
+            }
+            context.report(node, 'Avoid className prop on common component ' + name);
+        }
+    };
+};
+
+module.schema = [];

--- a/lib/rules/no-classname-on-common-components.js
+++ b/lib/rules/no-classname-on-common-components.js
@@ -1,19 +1,18 @@
-"use strict";
-var getProp = require('jsx-ast-utils/getProp');
+const getProp = require('jsx-ast-utils/getProp');
 
 module.exports = function(context) {
-    var options = context.options[0] || {components: []};
+    const options = context.options[0] || {components: []};
     return {
         JSXElement: function(node) {
-            var name = node.openingElement.name.name
+            const name = node.openingElement.name.name
             if (options.components.indexOf(name) === -1) {
                 return;
             }
-            var typeProp = getProp(node.openingElement.attributes, 'className');
+            const typeProp = getProp(node.openingElement.attributes, 'className');
             if (!typeProp) {
                 return;
             }
-            context.report(node, 'Avoid className prop on common component ' + name);
+            context.report(node, `Avoid className prop on common component ${name}`);
         }
     };
 };

--- a/package.json
+++ b/package.json
@@ -7,14 +7,15 @@
   "devDependencies": {
     "eslint": "2.8.0",
     "istanbul": "0.4.3",
+    "jsx-ast-utils": "2.0.1",
     "mocha": "2.4.5"
   },
   "scripts": {
     "test": "istanbul cover --dir reports/coverage node_modules/mocha/bin/_mocha tests/**/*.js -- --reporter dot"
   },
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/7Geese/eslint-plugin-7g.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/7Geese/eslint-plugin-7g.git"
   },
   "license": "ISC",
   "bugs": {

--- a/tests/lib/rules/moment-utc.js
+++ b/tests/lib/rules/moment-utc.js
@@ -1,9 +1,7 @@
-"use strict";
-
-var rule = require("../../../lib/rules/moment-utc"),
+const rule = require("../../../lib/rules/moment-utc"),
     RuleTester = require('eslint').RuleTester;
 
-var ruleTester = new RuleTester();
+const ruleTester = new RuleTester();
 ruleTester.run("moment-utc", rule, {
     valid: [
         "moment.utc()",

--- a/tests/lib/rules/no-classname-on-common-components.js
+++ b/tests/lib/rules/no-classname-on-common-components.js
@@ -19,6 +19,8 @@ ruleTester.run("no-classname-on-common-components", rule, {
         options: [{ components: ['Icon'] }]
     }, {
         code: '<ProfileImage imageUrl="test" />',
+    }, {
+        code: '<ProfileImage imageUrl="test" />',
         options: [{ components: ['ProfileImage'] }]
     }, {
         code: '<button type="submit" />',

--- a/tests/lib/rules/no-classname-on-common-components.js
+++ b/tests/lib/rules/no-classname-on-common-components.js
@@ -1,6 +1,4 @@
-"use strict";
-
-var rule = require("../../../lib/rules/no-classname-on-common-components"),
+const rule = require("../../../lib/rules/no-classname-on-common-components"),
     RuleTester = require('eslint').RuleTester;
 
 RuleTester.setDefaultConfig({
@@ -11,7 +9,7 @@ RuleTester.setDefaultConfig({
         },
     }
 });
-var ruleTester = new RuleTester();
+const ruleTester = new RuleTester();
 
 ruleTester.run("no-classname-on-common-components", rule, {
     valid: [{

--- a/tests/lib/rules/no-classname-on-common-components.js
+++ b/tests/lib/rules/no-classname-on-common-components.js
@@ -13,7 +13,7 @@ RuleTester.setDefaultConfig({
 });
 var ruleTester = new RuleTester();
 
-ruleTester.run("moment-utc", rule, {
+ruleTester.run("no-classname-on-common-components", rule, {
     valid: [{
         code: '<ProfileImage imageUrl="test" />',
         options: [{ components: ['Icon'] }]

--- a/tests/lib/rules/no-classname-on-common-components.js
+++ b/tests/lib/rules/no-classname-on-common-components.js
@@ -1,0 +1,27 @@
+"use strict";
+
+var rule = require("../../../lib/rules/no-classname-on-common-components"),
+    RuleTester = require('eslint').RuleTester;
+
+RuleTester.setDefaultConfig({
+    parserOptions: {
+        ecmaVersion: 6,
+        ecmaFeatures: {
+            jsx: true,
+        },
+    }
+});
+var ruleTester = new RuleTester();
+
+ruleTester.run("moment-utc", rule, {
+    valid: [
+        '<ProfileImage imageUrl="test" />',
+        '<button type="submit" />'
+    ],
+    invalid: [
+        {
+            code: '<ProfileImage className="cool-class-name" />',
+            errors: [{ message: "Avoid className prop on common component ProfileImage"}]
+        }
+    ]
+});

--- a/tests/lib/rules/no-classname-on-common-components.js
+++ b/tests/lib/rules/no-classname-on-common-components.js
@@ -14,14 +14,19 @@ RuleTester.setDefaultConfig({
 var ruleTester = new RuleTester();
 
 ruleTester.run("moment-utc", rule, {
-    valid: [
-        '<ProfileImage imageUrl="test" />',
-        '<button type="submit" />'
-    ],
-    invalid: [
-        {
-            code: '<ProfileImage className="cool-class-name" />',
-            errors: [{ message: "Avoid className prop on common component ProfileImage"}]
-        }
-    ]
+    valid: [{
+        code: '<ProfileImage imageUrl="test" />',
+        options: [{ components: ['Icon'] }]
+    }, {
+        code: '<ProfileImage imageUrl="test" />',
+        options: [{ components: ['ProfileImage'] }]
+    }, {
+        code: '<button type="submit" />',
+        options: [{ components: ['ProfileImage'] }]
+    }],
+    invalid: [{
+        code: '<ProfileImage className="cool-class-name" />',
+        options: [{ components: ['ProfileImage'] }],
+        errors: [{ message: "Avoid className prop on common component ProfileImage"}]
+    }]
 });


### PR DESCRIPTION
### Why?
Just need to add a reminder to avoid using className on components like Icon, ProfileImage, etc..