### PR TITLE
Add eslint rule to remind people to favour components instead of others

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,14 @@
 module.exports = {
     rules: {
         'moment-utc': require('./lib/rules/moment-utc'),
+        'favour-component': require('./lib/rules/favour-component'),
         'no-classname-on-common-components': require('./lib/rules/no-classname-on-common-components')
     },
     configs: {
         recommended: {
             rules: {
                 '7g/moment-utc': 1,
+                '7g/favour-component': 1,
                 '7g/no-classname-on-common-components': 1
             }
         }

--- a/lib/rules/favour-component.js
+++ b/lib/rules/favour-component.js
@@ -1,0 +1,14 @@
+module.exports = function(context) {
+    const options = context.options[0] || {components: {}};
+    return {
+        JSXElement: function(node) {
+            const name = node.openingElement.name.name
+            if (!options.components[name]) {
+                return;
+            }
+            context.report(node, `Please use ${options.components[name]} instead of ${name}`);
+        }
+    };
+};
+
+module.schema = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-7g",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "7geese eslint rules",
   "main": "index.js",
   "author": "Sean Everest",

--- a/tests/lib/rules/favour-component.js
+++ b/tests/lib/rules/favour-component.js
@@ -1,0 +1,26 @@
+const rule = require("../../../lib/rules/favour-component"),
+    RuleTester = require('eslint').RuleTester;
+
+RuleTester.setDefaultConfig({
+    parserOptions: {
+        ecmaVersion: 6,
+        ecmaFeatures: {
+            jsx: true,
+        },
+    }
+});
+const ruleTester = new RuleTester();
+
+ruleTester.run("favour-component", rule, {
+    valid: [{
+        code: '<ProfileImage imageUrl="test" />',
+        options: [{ components: {Icon: 'Icon2'}}]
+    }, {
+        code: '<ProfileImage imageUrl="test" />',
+    }],
+    invalid: [{
+        code: '<ProfileImage className="cool-class-name" />',
+        options: [{ components: {ProfileImage: 'ProfileImage2'}}],
+        errors: [{ message: "Please use ProfileImage2 instead of ProfileImage"}]
+    }]
+});


### PR DESCRIPTION
### Description

Add rule to show an error or warning when a component should be used instead of an other.

`Icon2` instead of `Icon` for example.

### Test

- [ ] Code looks good
- [ ] Tests look good