### PR TITLE
✨[new] Adds apollo-query-filenames rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,13 @@
 
 module.exports = {
     rules: {
-        'no-classname-on-common-components': require('./rules/no-classname-on-common-components'),
+        'apollo-query-filenames': require('./rules/apollo-query-filenames.js'),
+        'no-classname-on-common-components': require('./rules/no-classname-on-common-components.js'),
     },
     configs: {
         recommended: {
             rules: {
+                '7g/apollo-query-filenames': 'error',
                 '7g/no-classname-on-common-components': 'warn',
             },
         },

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
     testPathIgnorePatterns: [
         '/node_modules/',
-        '/__fixtures/',
+        '/__fixtures__/',
     ],
     verbose: true,
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+    testPathIgnorePatterns: [
+        '/node_modules/',
+        '/__fixtures/',
+    ],
+    verbose: true,
+};

--- a/rules/__tests__/__fixtures__/apollo-query-filename.fixture.js
+++ b/rules/__tests__/__fixtures__/apollo-query-filename.fixture.js
@@ -1,0 +1,39 @@
+const exampleQuery = `
+import gql from 'graphql-tag';
+
+export default {
+    query: gql\`
+    query myQuery {
+        admins: profiles(first: 780, isAdmin: true, activationState: 1) {
+            edges {
+                node {
+                    pk
+                    fullName
+                }
+            }
+        }
+    }
+    \`
+}
+`;
+
+const exampleMutation = `
+import gql from 'graphql-tag';
+
+export default {
+    mutation: gql\`
+    mutation myMutation($enabled: Boolean!) {
+        updateTalentIndicatorSettings(enabled: $enabled) {
+            network {
+                enableTalentIndicators
+            }
+        }
+    }
+    \`
+}
+`;
+
+module.exports = {
+    exampleQuery,
+    exampleMutation,
+};

--- a/rules/__tests__/apollo-query-filename.js
+++ b/rules/__tests__/apollo-query-filename.js
@@ -1,0 +1,45 @@
+const { RuleTester } = require('eslint');
+
+const rule = require('../apollo-query-filenames.js');
+
+const { exampleQuery, exampleMutation } = require('./__fixtures__/apollo-query-filename.fixture.js');
+
+
+RuleTester.setDefaultConfig({
+    parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module',
+    },
+});
+
+const ruleTester = new RuleTester();
+
+
+ruleTester.run('apollo-query-filenames', rule, {
+    valid: [
+        {
+            code: exampleQuery,
+            filename: 'my-query.js',
+        },
+        {
+            code: exampleMutation,
+            filename: 'my-mutation.js',
+        },
+    ],
+    invalid: [
+        {
+            code: exampleQuery,
+            filename: 'my-uhh-i-forget-what-its-called.js',
+            errors: [{
+                message: 'Filename for Apollo queries must end with "-query.js"',
+            }],
+        },
+        {
+            code: exampleMutation,
+            filename: 'my-uhh-thingy-that-sends-data.js',
+            errors: [{
+                message: 'Filename for Apollo mutations must end with "-mutation.js"',
+            }],
+        },
+    ],
+});

--- a/rules/apollo-query-filenames.js
+++ b/rules/apollo-query-filenames.js
@@ -1,0 +1,57 @@
+
+module.exports = function (context) {
+    const fileName = context.getFilename();
+    const testFileName = pattern => pattern.test(fileName);
+    const isValidQueryFilename = testFileName(/-query.js$/);
+    const isValidMutationFilename = testFileName(/-mutation.js$/);
+    let areWeInFlavorTown = false;
+
+    const getLocForReport = (node) => {
+        const { parent } = node;
+        if (!parent || !parent.loc) {
+            return {};
+        }
+        return {
+            loc: parent.loc,
+        };
+    };
+
+    const messages = {
+        query: 'Filename for Apollo queries must end with "-query.js"',
+        mutation: 'Filename for Apollo mutations must end with "-mutation.js"',
+    };
+
+    const report = (node, type) => {
+        const loc = getLocForReport(node);
+        return context.report(Object.assign({}, loc, {
+            node,
+            message: messages[type],
+        }));
+    };
+
+    return {
+        ImportDeclaration(node) {
+            const { type, value } = node.source;
+            if (type === 'Literal' && value === 'graphql-tag') {
+                areWeInFlavorTown = true;
+            }
+        },
+        ExportDefaultDeclaration(node) {
+            if (areWeInFlavorTown) {
+                const { declaration } = node;
+                if (!declaration || !declaration.properties) {
+                    return;
+                }
+                const propKeys = declaration.properties.map(({ key }) => key.name);
+                if (propKeys.includes('query') && !isValidQueryFilename) {
+                    report(node, 'query');
+                }
+                if (propKeys.includes('mutation') && !isValidMutationFilename) {
+                    report(node, 'mutation');
+                }
+            }
+        },
+    };
+};
+
+module.schema = [];


### PR DESCRIPTION
### Description

Adds `apollo-query-filenames` rule to enforce that all Apollo query and mutation files end with `-query.js` or `-mutation.js`.


_Caveats: Does not yet support fragments._