### PR TITLE
[New Rule] add button-has-text-or-child rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules/
 *yarn-error.log
 *npm-error.log
 *__benchmark.snapshot__.json
+
+.idea/
+

--- a/docs/rules/__rule-template__.md
+++ b/docs/rules/__rule-template__.md
@@ -28,7 +28,7 @@ Explain how the rule would be configured in the `.eslintrc` of a consumer. Inclu
     "rules": {
         "7g/rule-name": ["error", {
             "some-option": true
-        }],
+        }]
     }
 }
 ```

--- a/docs/rules/button-has-text-or-child.md
+++ b/docs/rules/button-has-text-or-child.md
@@ -1,0 +1,44 @@
+## button-has-text-or-child
+> _7Geese common component for buttons cannot have both children and a text prop at the same time._
+
+Originally the button only supported use via children i.e.
+```jsx
+    <Button>Click me</Button>
+```
+
+Now we added the text prop to support translation via google translate.
+You cannot use them at the same time.
+
+### Fail
+
+The following patterns are considered errors:
+
+```jsx
+<Button text="do not click me">
+    Click me
+</Button>
+```
+
+### Pass
+
+The following patterns are **not** considered errors:
+
+```jsx
+<Button text="Click me" />
+```
+
+```jsx
+<Button>
+    Click me
+</Button
+```
+
+### Rule Configuration
+
+```json
+{
+    "rules": {
+        "7g/button-has-text-or-child": true
+    }
+}
+```

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = {
                 '7g/no-classname-on-common-components': 'warn',
                 '7g/no-sg-in-components': 'warn',
                 '7g/redux-connect-filenames': 'error',
+                '7g/button-has-text-or-child': 'off',
             },
         },
         on: {
@@ -22,6 +23,7 @@ module.exports = {
                 '7g/no-classname-on-common-components': 'error',
                 '7g/no-sg-in-components': 'warn',
                 '7g/redux-connect-filenames': 'error',
+                '7g/button-has-text-or-child': 'warn',
             },
         },
         off: {
@@ -30,6 +32,7 @@ module.exports = {
                 '7g/no-classname-on-common-components': 'off',
                 '7g/no-sg-in-components': 'off',
                 '7g/redux-connect-filenames': 'off',
+                '7g/button-has-text-or-child': 'off',
             },
         },
     },

--- a/lib/rules/__tests__/button-has-text-or-child.spec.js
+++ b/lib/rules/__tests__/button-has-text-or-child.spec.js
@@ -21,5 +21,11 @@ ruleTester.run('no-classname-on-common-components', rule, {
     invalid: [{
         code: '<Button text="Test">Test</Button>',
         errors: [{ message: 'Cannot use both prop text and children on 7G button component'}],
+    }, {
+        code: '<Button onClick={() => null} icon="arrow-down" text="Test">Test</Button>',
+        errors: [{ message: 'Cannot use both prop text and children on 7G button component'}],
+    }, {
+        code: '<Button.Outline text="Test">Test</Button.Outline>',
+        errors: [{ message: 'Cannot use both prop text and children on 7G button component'}],
     }],
 });

--- a/lib/rules/__tests__/button-has-text-or-child.spec.js
+++ b/lib/rules/__tests__/button-has-text-or-child.spec.js
@@ -12,7 +12,7 @@ const ruleTester = getRuleTester({
     },
 });
 
-ruleTester.run('no-classname-on-common-components', rule, {
+ruleTester.run('button-has-text-or-child', rule, {
     valid: [{
         code: '<Button text="Test" />',
     }, {

--- a/lib/rules/__tests__/button-has-text-or-child.spec.js
+++ b/lib/rules/__tests__/button-has-text-or-child.spec.js
@@ -1,0 +1,25 @@
+const rule = require('../button-has-text-or-child.js');
+
+const getRuleTester = require('./__rule-tester-config__.js');
+
+
+const ruleTester = getRuleTester({
+    parserOptions: {
+        ecmaVersion: 6,
+        ecmaFeatures: {
+            jsx: true,
+        },
+    },
+});
+
+ruleTester.run('no-classname-on-common-components', rule, {
+    valid: [{
+        code: '<Button text="Test" />',
+    }, {
+        code: '<Button>Test</Button>',
+    }],
+    invalid: [{
+        code: '<Button text="Test">Test</Button>',
+        errors: [{ message: 'Cannot use both prop text and children on 7G button component'}],
+    }],
+});

--- a/lib/rules/button-has-text-or-child.js
+++ b/lib/rules/button-has-text-or-child.js
@@ -1,0 +1,36 @@
+
+module.exports = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'disallow using text and children at the same time on 7g buttons',
+            category: 'Error',
+            recommended: false,
+        },
+    },
+    create(context) {
+        return {
+            JSXElement(node) {
+                // if has children elements
+                if (node.closingElement === null) {
+                    return;
+                }
+                const openingEl = node.openingElement;
+                if (openingEl && openingEl.name) {
+                    const { name } = openingEl.name;
+                    if (name !== 'Button') {
+                        return;
+                    }
+                    if (!openingEl.attributes.length) {
+                        return;
+                    }
+                    const props = openingEl.attributes.map(attr => attr.name.name);
+                    const containsTextProp = props.includes('text');
+                    if (containsTextProp) {
+                        context.report(node, 'Cannot use both prop text and children on 7G button component');
+                    }
+                }
+            },
+        };
+    },
+};

--- a/lib/rules/button-has-text-or-child.js
+++ b/lib/rules/button-has-text-or-child.js
@@ -11,16 +11,19 @@ module.exports = {
     create(context) {
         return {
             JSXElement(node) {
-                // if has children elements
+                // if there is no closing element i.e. it is <Button /> then the rule doesn't apply
                 if (node.closingElement === null) {
                     return;
                 }
                 const openingEl = node.openingElement;
-                if (openingEl && openingEl.name) {
-                    const { name } = openingEl.name;
+                // check if the opening is a Button component
+                if (openingEl && (openingEl.name || openingEl.tagName)) {
+                    const name = getName(openingEl);
+                    // if it's not a button the rule doesn't apply
                     if (name !== 'Button') {
                         return;
                     }
+                    // if there are no props, the rule doesn't apply because there can't be a text prop
                     if (!openingEl.attributes.length) {
                         return;
                     }
@@ -33,4 +36,9 @@ module.exports = {
             },
         };
     },
+};
+
+const getName = function (element) { // The difference between Button and a sub type like Button.Minimal in the AST
+    const { name } = element;
+    return name.name || name.object.name;
 };


### PR DESCRIPTION
For 7G button common component we don't allow use of text and children at the same time.

Why not lint for it.